### PR TITLE
fixing the github address that shows up on search.npmjs.org

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
  },
  "repository": {
   "type": "git",
-  "url": "http://github.com/malgorithms/node-toffee"
+  "url": "http://github.com/malgorithms/toffee"
  },
  "devDependencies": {
   "iced-coffee-script": "1.3.1a"


### PR DESCRIPTION
Hello, I came across your project from http://search.npmjs.org but it currently shows the wrong github link.
So I searched for `toffee` in github, found the project and fixed the packages.json :)
