### PR TITLE
Fix dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
  "author": "Chris Coyne <ccoyne77@gmail.com>",
  "bin": "./bin/toffee",
  "dependencies": {
- 	"coffee-script": "*",
- 	"commander":     "*",
- 	"uglify-js":     "*",
+  "coffee-script": "*",
+  "commander":     "*",
+  "uglify-js":     "*",
   "mkdirp":        "*"
  },
  "devDependencies": {
- 	"jison" :        "*"
+  "jison" :        "*"
  },
  "repository": {
   "type": "git",


### PR DESCRIPTION
"mkdirp" is a real dependency, not just a devDependency, as it is used in the command_line.coffee.

v0.0.42 has a broken command-line tool because of this dependency error.
