### PR TITLE
render_no_args: calling render on browser with no args crashes

### DIFF
--- a/src/view.coffee
+++ b/src/view.coffee
@@ -495,6 +495,7 @@ class view
 #{__}tmpl = toffee.templates["#{@bundlePath}"]  =
 #{__}  bundlePath: "#{@bundlePath}"
 #{__}tmpl.render = tmpl.pub = (__locals) ->
+#{__}#{___}__locals = __locals or {}
 #{__}#{___}_to = (x) -> __locals.__toffee.out.push x
 #{__}#{___}_ln = (x) -> __locals.__toffee.lineno = x
 #{__}#{___}_ts = (x) -> __locals.__toffee.state  = x

--- a/test/cases/render_no_args/input.toffee
+++ b/test/cases/render_no_args/input.toffee
@@ -1,0 +1,1 @@
+No arguments passed.

--- a/test/cases/render_no_args/output.toffee
+++ b/test/cases/render_no_args/output.toffee
@@ -1,0 +1,1 @@
+No arguments passed.

--- a/test/generate_express_test.coffee
+++ b/test/generate_express_test.coffee
@@ -59,7 +59,10 @@ generateExpressTest = (cb) ->
       if path.existsSync "./test/cases/#{dir}/vars.js"
         vars     = fs.readFileSync "./test/cases/#{dir}/vars.js", "utf8"
       else
-        vars     = "{}"
+        if dir == "render_no_args"
+          vars = ""
+        else
+          vars     = "{}"
       rid = i
       test_page += """
         \n\n\n<!-- ************ #{dir} -->


### PR DESCRIPTION
Typically, this isn't a problem, because people are good citizens and call render() with arguments, but if they don't, things blow up. This fixes that and adds a test.
