### PR TITLE
Cakefile updated to support CoffeeScript 1.7.0+

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -1,3 +1,4 @@
+require 'coffee-script/register'
 {spawn, exec}          = require 'child_process'
 fs                     = require 'fs'
 jison                  = require 'jison'


### PR DESCRIPTION
As of [this PR](https://github.com/jashkenas/coffee-script/pull/3279),
CoffeeScript now requires Cakefiles to register their local coffee
installation as to ensure version compatibility.
